### PR TITLE
fix can not use object of type config as array

### DIFF
--- a/src/Middleware/Connector.php
+++ b/src/Middleware/Connector.php
@@ -110,7 +110,7 @@ class Connector
 
         // Add Secret Token to Header
         if ($this->config->get('secretToken') !== null) {
-            $headers['Authorization'] = sprintf('Bearer %s', $this->config['secretToken']);
+            $headers['Authorization'] = sprintf('Bearer %s', $this->config->get('secretToken'));
         }
 
         return $headers;


### PR DESCRIPTION
references https://github.com/philkra/elastic-apm-php-agent/issues/13