### PR TITLE
Allows specifying a context to merge with the shared context for every capture or transaction

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -107,13 +107,14 @@ class Agent
      * @throws \PhilKra\Exception\Transaction\DuplicateTransactionNameException
      *
      * @param string $name
+     * @param array  $context
      *
      * @return Transaction
      */
-    public function startTransaction(string $name): Transaction
+    public function startTransaction(string $name, array $context = []): Transaction
     {
         // Create and Store Transaction
-        $this->transactionsStore->register(new Transaction($name, $this->sharedContext));
+        $this->transactionsStore->register(new Transaction($name, array_replace_recursive($this->sharedContext, $context)));
 
         // Start the Transaction
         $transaction = $this->transactionsStore->fetch($name);
@@ -163,12 +164,13 @@ class Agent
      * @link http://php.net/manual/en/class.throwable.php
      *
      * @param \Throwable $thrown
+     * @param array      $context
      *
      * @return void
      */
-    public function captureThrowable(\Throwable $thrown)
+    public function captureThrowable(\Throwable $thrown, array $context = [])
     {
-        $this->errorsStore->register(new Error($thrown, $this->sharedContext));
+        $this->errorsStore->register(new Error($thrown, array_replace_recursive($this->sharedContext, $context)));
     }
 
     /**


### PR DESCRIPTION
This PR allows an additional context to be provided on every capture or transaction. 

A use case for us is that we use the agent early on in the bootstrapping of our application. At these stages we don't necessarily know the authenticated user will be (if any) and as such cannot provide this in the context provided to the agent constructor.

Instead we use this PR to provide it when it is available.