### PR TITLE
Return transaction duration in milliseconds

### DIFF
--- a/src/Events/Transaction.php
+++ b/src/Events/Transaction.php
@@ -81,7 +81,7 @@ class Transaction extends EventBean implements \JsonSerializable
         $this->timer->stop();
 
         // Store Summary
-        $this->summary['duration']  = $duration ?? round($this->timer->getDuration(), 3);
+        $this->summary['duration']  = $duration ?? round($this->timer->getDurationInMilliseconds(), 3);
         $this->summary['headers']   = (function_exists('xdebug_get_headers') === true) ? xdebug_get_headers() : [];
         $this->summary['backtrace'] = debug_backtrace();
     }

--- a/src/Helper/Timer.php
+++ b/src/Helper/Timer.php
@@ -51,7 +51,7 @@ class Timer
     }
 
     /**
-     * Get the elapsed Duration of this Timer
+     * Get the elapsed Duration of this Timer in MicroSeconds
      *
      * @throws \PhilKra\Exception\Timer\NotStoppedException
      *
@@ -67,7 +67,23 @@ class Timer
     }
 
     /**
-     * Get the current elapsed Interval of the Timer
+     * Get the elapsed Duration of this Timer in MilliSeconds
+     *
+     * @throws \PhilKra\Exception\Timer\NotStoppedException
+     *
+     * @return float
+     */
+    public function getDurationInMilliseconds() : float
+    {
+        if ($this->stoppedOn === null) {
+            throw new NotStoppedException();
+        }
+
+        return $this->toMilli($this->stoppedOn - $this->startedOn);
+    }
+
+    /**
+     * Get the current elapsed Interval of the Timer in MicroSeconds
      *
      * @throws \PhilKra\Exception\Timer\NotStartedException
      *
@@ -85,6 +101,24 @@ class Timer
     }
 
     /**
+     * Get the current elapsed Interval of the Timer in MilliSeconds
+     *
+     * @throws \PhilKra\Exception\Timer\NotStartedException
+     *
+     * @return float
+     */
+    public function getElapsedInMilliseconds() : float
+    {
+        if ($this->startedOn === null) {
+            throw new NotStartedException();
+        }
+
+        return ($this->stoppedOn === null) ?
+            $this->toMilli(microtime(true) - $this->startedOn) :
+            $this->getDurationInMilliseconds();
+    }
+
+    /**
      * Convert the Duration from Seconds to Micro-Seconds
      *
      * @param  float $num
@@ -94,5 +128,17 @@ class Timer
     private function toMicro(float $num) : float
     {
         return $num * 1000000;
+    }
+
+    /**
+     * Convert the Duration from Seconds to Milli-Seconds
+     *
+     * @param  float $num
+     *
+     * @return float
+     */
+    private function toMilli(float $num) : float
+    {
+        return $num * 1000;
     }
 }

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -3,7 +3,6 @@ namespace PhilKra\Tests;
 
 use \PhilKra\Agent;
 use \PhilKra\Transaction\Summary;
-use \PHPUnit\Framework\TestCase;
 
 /**
  * Test Case for @see \PhilKra\Agent
@@ -22,7 +21,7 @@ final class AgentTest extends TestCase {
     // Create a Transaction, wait and Stop it
     $name = 'trx';
     $agent->startTransaction( $name );
-    usleep( 10 );
+    usleep( 10 * 1000 ); // sleep milliseconds
     $agent->stopTransaction( $name );
 
     // Transaction Summary must be populated
@@ -31,7 +30,8 @@ final class AgentTest extends TestCase {
     $this->assertArrayHasKey( 'duration', $summary );
     $this->assertArrayHasKey( 'backtrace', $summary );
 
-    $this->assertGreaterThanOrEqual( 10, $summary['duration'] );
+    // Expect duration in milliseconds
+    $this->assertDurationIsWithinThreshold(10, $summary['duration']);
     $this->assertNotEmpty( $summary['backtrace'] );
   }
 

--- a/tests/Helper/ConfigTest.php
+++ b/tests/Helper/ConfigTest.php
@@ -2,8 +2,7 @@
 namespace PhilKra\Tests\Helper;
 
 use \PhilKra\Agent;
-use \PhilKra\Helper\Config;
-use \PHPUnit\Framework\TestCase;
+use PhilKra\Tests\TestCase;
 
 /**
  * Test Case for @see \PhilKra\Helper\Config

--- a/tests/Helper/TimerTest.php
+++ b/tests/Helper/TimerTest.php
@@ -2,7 +2,7 @@
 namespace PhilKra\Tests\Helper;
 
 use \PhilKra\Helper\Timer;
-use \PHPUnit\Framework\TestCase;
+use PhilKra\Tests\TestCase;
 
 /**
  * Test Case for @see \PhilKra\Helper\Timer
@@ -26,7 +26,24 @@ final class TimerTest extends TestCase {
     $this->assertGreaterThanOrEqual( $duration, $timer->getDuration() );
   }
 
-  /**
+    /**
+     * @covers \PhilKra\Helper\Timer::start
+     * @covers \PhilKra\Helper\Timer::stop
+     * @covers \PhilKra\Helper\Timer::getDuration
+     * @covers \PhilKra\Helper\Timer::toMicro
+     */
+    public function testCanCalculateDurationInMilliseconds() {
+        $timer = new Timer();
+        $duration = rand( 25, 100 ); // duration in milliseconds
+
+        $timer->start();
+        usleep( $duration * 1000 ); // sleep microseconds
+        $timer->stop();
+
+        $this->assertDurationIsWithinThreshold($duration, $timer->getDurationInMilliseconds());
+    }
+
+    /**
    * @depends testCanBeStartedAndStoppedWithDuration
    *
    * @covers \PhilKra\Helper\Timer::start

--- a/tests/Stores/ErrorsStoreTest.php
+++ b/tests/Stores/ErrorsStoreTest.php
@@ -3,8 +3,7 @@ namespace PhilKra\Tests\Stores;
 
 use \PhilKra\Stores\ErrorsStore;
 use \PhilKra\Events\Error;
-use \PhilKra\Exception\Transaction\DuplicateTransactionNameException;
-use \PHPUnit\Framework\TestCase;
+use PhilKra\Tests\TestCase;
 
 /**
  * Test Case for @see \PhilKra\Stores\ErrorsStore

--- a/tests/Stores/TransactionsStoreTest.php
+++ b/tests/Stores/TransactionsStoreTest.php
@@ -3,8 +3,7 @@ namespace PhilKra\Tests\Stores;
 
 use \PhilKra\Stores\TransactionsStore;
 use \PhilKra\Events\Transaction;
-use \PhilKra\Exception\Transaction\DuplicateTransactionNameException;
-use \PHPUnit\Framework\TestCase;
+use PhilKra\Tests\TestCase;
 
 /**
  * Test Case for @see \PhilKra\Stores\TransactionsStore

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: tepeds
+ * Date: 2019-02-09
+ * Time: 10:49
+ */
+
+namespace PhilKra\Tests;
+
+
+abstract class TestCase extends \PHPUnit\Framework\TestCase
+{
+
+    protected function assertDurationIsWithinThreshold(int $sleptMilliseconds, float $timedDuration)
+    {
+        $this->assertGreaterThanOrEqual( $sleptMilliseconds, $timedDuration );
+
+        // Generally we should expect less than 1ms of overhead, but that is not guaranteed.
+        // 10ms should be enough unless the test system is really unresponsive.
+        $overhead = ($timedDuration - $sleptMilliseconds);
+        $this->assertLessThanOrEqual( 10, $overhead );
+    }
+
+}


### PR DESCRIPTION
I consider this to a a work-in-progress, not something I expect to have merged as-is.

I added a method to return the duration in milliseconds rather than modifying the current method. If you don't see any reason to keep the old method, I'll remove it. This change does appear to be generated the correct results for me.

Testing the duration is awkward since there is overhead at the millisecond level. Sleeping for 10 milliseconds does not result in an exact duration of 10 milliseconds. I put in a reasonable threshold test, but I'm curious what you opinion is.