### PR TITLE
Add service environment to config and serialized transaction

### DIFF
--- a/src/Helper/Config.php
+++ b/src/Helper/Config.php
@@ -70,6 +70,7 @@ class Config
             'apmVersion'  => 'v1',
             'env'         => [],
             'httpClient'  => [],
+            'environment' => 'development',
         ];
     }
 }

--- a/src/Serializers/Entity.php
+++ b/src/Serializers/Entity.php
@@ -51,7 +51,8 @@ class Entity
                 'agent' => [
                     'name'    => Agent::NAME,
                     'version' => Agent::VERSION
-                ]
+                ],
+                'environment' => $this->config->get('environment')
             ],
             'system' => [
                 'hostname'     => $this->config->get('hostname'),

--- a/tests/Helper/ConfigTest.php
+++ b/tests/Helper/ConfigTest.php
@@ -32,6 +32,7 @@ final class ConfigTest extends TestCase {
     $this->assertArrayHasKey( 'appVersion', $config );
     $this->assertArrayHasKey( 'env', $config );
     $this->assertArrayHasKey( 'httpClient', $config );
+    $this->assertArrayHasKey( 'environment', $config );
 
     $this->assertEquals( $config['appName'], $appName );
     $this->assertNull( $config['secretToken'] );
@@ -42,6 +43,7 @@ final class ConfigTest extends TestCase {
     $this->assertEquals( $config['apmVersion'], 'v1' );
     $this->assertEquals( $config['env'], [] );
     $this->assertEquals( $config['httpClient'], [] );
+    $this->assertEquals( $config['environment'], 'development' );
   }
 
   /**


### PR DESCRIPTION
This should be good to go. It allows filtering in APM such as:

```
context.service.environment:development
```