### PR TITLE
env and cookies can only be null or an object

### DIFF
--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -171,16 +171,16 @@ class EventBean
      * @link http://php.net/manual/en/reserved.variables.server.php
      * @link https://github.com/philkra/elastic-apm-php-agent/issues/27
      *
-     * @return array
+     * @return object
      */
-    final protected function getEnv() : ?array
+    final protected function getEnv() : object
     {
         $envMask = $this->contexts['env'];
         $env = empty($envMask)
             ? $_SERVER
             : array_intersect_key($_SERVER, array_flip($envMask));
 
-        return !empty($env) ? $env : null;
+        return (object) $env;
     }
 
     /**
@@ -188,16 +188,16 @@ class EventBean
      *
      * @link https://github.com/philkra/elastic-apm-php-agent/issues/30
      *
-     * @return array
+     * @return object
      */
-    final protected function getCookies() : ?array
+    final protected function getCookies() : object
     {
         $cookieMask = $this->contexts['cookies'];
         $cookies = empty($cookieMask)
             ? $_COOKIE
             : array_intersect_key($_COOKIE, array_flip($cookieMask));
 
-        return !empty($cookies) ? $cookies : null;
+        return (object) $cookies;
     }
 
     /**

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -173,12 +173,14 @@ class EventBean
      *
      * @return array
      */
-    final protected function getEnv() : array
+    final protected function getEnv() : ?array
     {
-        $env = $this->contexts['env'];
-        return ( empty( $env ) === true )
+        $envMask = $this->contexts['env'];
+        $env = empty($envMask)
             ? $_SERVER
-            : array_intersect_key($_SERVER, array_flip($env));
+            : array_intersect_key($_SERVER, array_flip($envMask));
+
+        return !empty($env) ? $env : null;
     }
 
     /**
@@ -188,13 +190,14 @@ class EventBean
      *
      * @return array
      */
-    final protected function getCookies() : array
+    final protected function getCookies() : ?array
     {
         $cookieMask = $this->contexts['cookies'];
-
-        return empty($cookieMask)
+        $cookies = empty($cookieMask)
             ? $_COOKIE
             : array_intersect_key($_COOKIE, array_flip($cookieMask));
+
+        return !empty($cookies) ? $cookies : null;
     }
 
     /**


### PR DESCRIPTION
After https://github.com/philkra/elastic-apm-php-agent/pull/45 was merged, we happily defined our allowed cookies but noticed another problem when running console commands: they have no cookies and when you encode `'cookies' => []`, it results in `"cookies": []` but Elastic APM only allows `"cookies": null` or `"cookies": {}`. The same also seems to apply to `env`.