### PR TITLE
48 allow explicit timer start

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -129,16 +129,19 @@ class Agent
      *
      * @return Transaction
      */
-    public function startTransaction(string $name, array $context = []): Transaction
+    public function startTransaction(string $name, array $context = [], float $start = null): Transaction
     {
         // Create and Store Transaction
         $this->transactionsStore->register(
-            $this->eventFactory->createTransaction($name, array_replace_recursive($this->sharedContext, $context))
+            $this->eventFactory->createTransaction($name, array_replace_recursive($this->sharedContext, $context), $start)
         );
 
         // Start the Transaction
         $transaction = $this->transactionsStore->fetch($name);
-        $transaction->start();
+
+        if (null === $start) {
+            $transaction->start();
+        }
 
         return $transaction;
     }

--- a/src/Events/DefaultEventFactory.php
+++ b/src/Events/DefaultEventFactory.php
@@ -15,8 +15,8 @@ final class DefaultEventFactory implements EventFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createTransaction(string $name, array $contexts): Transaction
+    public function createTransaction(string $name, array $contexts, float $start = null): Transaction
     {
-        return new Transaction($name, $contexts);
+        return new Transaction($name, $contexts, $start);
     }
 }

--- a/src/Events/EventFactoryInterface.php
+++ b/src/Events/EventFactoryInterface.php
@@ -20,5 +20,5 @@ interface EventFactoryInterface
      * @param string $name
      * @param array  $contexts
      */
-    public function createTransaction(string $name, array $contexts): Transaction;
+    public function createTransaction(string $name, array $contexts, float $start = null): Transaction;
 }

--- a/src/Events/Transaction.php
+++ b/src/Events/Transaction.php
@@ -51,11 +51,11 @@ class Transaction extends EventBean implements \JsonSerializable
     * @param string $name
     * @param array $contexts
     */
-    public function __construct(string $name, array $contexts)
+    public function __construct(string $name, array $contexts, $start = null)
     {
         parent::__construct($contexts);
         $this->setTransactionName($name);
-        $this->timer = new Timer();
+        $this->timer = new Timer($start);
     }
 
     /**

--- a/src/Exception/Timer/AlreadyRunningException.php
+++ b/src/Exception/Timer/AlreadyRunningException.php
@@ -1,0 +1,13 @@
+<?php
+namespace PhilKra\Exception\Timer;
+
+/**
+ * Trying to stop a Timer that is already running
+ */
+class AlreadyRunningException extends \Exception {
+
+  public function __construct( string $message = '', int $code = 0, \Throwable $previous = NULL ) {
+    parent::__construct( 'Can\'t start a timer which is already running.', $code, $previous );
+  }
+
+}

--- a/src/Helper/Timer.php
+++ b/src/Helper/Timer.php
@@ -2,6 +2,7 @@
 
 namespace PhilKra\Helper;
 
+use PhilKra\Exception\Timer\AlreadyRunningException;
 use PhilKra\Exception\Timer\NotStartedException;
 use PhilKra\Exception\Timer\NotStoppedException;
 
@@ -33,9 +34,14 @@ class Timer
      * Start the Timer
      *
      * @return void
+     * @throws AlreadyRunningException
      */
     public function start()
     {
+        if (null !== $this->startedOn) {
+            throw new AlreadyRunningException();
+        }
+        
         $this->startedOn = microtime(true);
     }
 

--- a/src/Helper/Timer.php
+++ b/src/Helper/Timer.php
@@ -24,6 +24,11 @@ class Timer
      */
     private $stoppedOn = null;
 
+    public function __construct(float $startTime = null)
+    {
+        $this->startedOn = $startTime;
+    }
+
     /**
      * Start the Timer
      *

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -36,6 +36,32 @@ final class AgentTest extends TestCase {
   }
 
   /**
+   * @covers \PhilKra\Agent::__construct
+   * @covers \PhilKra\Agent::startTransaction
+   * @covers \PhilKra\Agent::stopTransaction
+   * @covers \PhilKra\Agent::getTransaction
+   */
+  public function testStartAndStopATransactionWithExplicitStart() {
+    $agent = new Agent( [ 'appName' => 'phpunit_1' ] );
+
+    // Create a Transaction, wait and Stop it
+    $name = 'trx';
+    $agent->startTransaction( $name, [], microtime(true) - 1);
+    usleep( 500 * 1000 ); // sleep milliseconds
+    $agent->stopTransaction( $name );
+
+    // Transaction Summary must be populated
+    $summary = $agent->getTransaction( $name )->getSummary();
+
+    $this->assertArrayHasKey( 'duration', $summary );
+    $this->assertArrayHasKey( 'backtrace', $summary );
+
+    // Expect duration in milliseconds
+    $this->assertDurationIsWithinThreshold(1500, $summary['duration'], 150);
+    $this->assertNotEmpty( $summary['backtrace'] );
+  }
+
+  /**
    * @depends testStartAndStopATransaction
    *
    * @covers \PhilKra\Agent::__construct

--- a/tests/Helper/TimerTest.php
+++ b/tests/Helper/TimerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace PhilKra\Tests\Helper;
 
+use PhilKra\Exception\Timer\AlreadyRunningException;
 use \PhilKra\Helper\Timer;
 use PhilKra\Tests\TestCase;
 
@@ -108,5 +109,15 @@ final class TimerTest extends TestCase {
         // Duration should be more than 1000 milliseconds
         //  sum of initial offset and sleep
         $this->assertGreaterThanOrEqual(1000, $duration);
+    }
+
+    /**
+     * @covers \PhilKra\Helper\Timer::start
+     */
+    public function testCannotBeStartedIfAlreadyRunning() {
+        $timer = new Timer(microtime(true));
+
+        $this->expectException(AlreadyRunningException::class);
+        $timer->start();
     }
 }

--- a/tests/Helper/TimerTest.php
+++ b/tests/Helper/TimerTest.php
@@ -92,4 +92,21 @@ final class TimerTest extends TestCase {
     $timer->stop();
   }
 
+    /**
+     * @covers \PhilKra\Helper\Timer::start
+     * @covers \PhilKra\Helper\Timer::getDurationInMilliseconds
+     */
+    public function testCanBeStartedWithExplicitStartTime() {
+        $timer = new Timer(microtime(true) - .5); // Start timer 500 milliseconds ago
+
+        usleep(500 * 1000); // Sleep for 500 milliseconds
+
+        $timer->stop();
+
+        $duration = $timer->getDurationInMilliseconds();
+
+        // Duration should be more than 1000 milliseconds
+        //  sum of initial offset and sleep
+        $this->assertGreaterThanOrEqual(1000, $duration);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,14 +12,12 @@ namespace PhilKra\Tests;
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
 
-    protected function assertDurationIsWithinThreshold(int $sleptMilliseconds, float $timedDuration)
+    protected function assertDurationIsWithinThreshold(int $expectedMilliseconds, float $timedDuration, float $maxOverhead = 10)
     {
-        $this->assertGreaterThanOrEqual( $sleptMilliseconds, $timedDuration );
+        $this->assertGreaterThanOrEqual( $expectedMilliseconds, $timedDuration );
 
-        // Generally we should expect less than 1ms of overhead, but that is not guaranteed.
-        // 10ms should be enough unless the test system is really unresponsive.
-        $overhead = ($timedDuration - $sleptMilliseconds);
-        $this->assertLessThanOrEqual( 10, $overhead );
+        $overhead = ($timedDuration - $expectedMilliseconds);
+        $this->assertLessThanOrEqual( $maxOverhead, $overhead );
     }
 
 }


### PR DESCRIPTION
This is a draft PR so we can discuss this proposed change.

The change I need here is in support of changes in the Laravel package which uses these classes. Specifically, I want to use a Timer object but I must be able to set a start time rather than having the timer start when created. That isolated change is pretty easy and seems save.

At the same time, it makes sense to expose that capability through the existing Timer creational methods, which means updating the EventFactoryInterface, Transaction and Agent classes. The start time parameter is optional and safely defaults to `null` so should have no impact on existing use cases.

Any subclasses of the EventFactoryInterface will need to update the createTransaction method signature however.

I believe this change makes the Timer class usable in more circumstances without compromising current behavior.