### PR TITLE
Added support for forwarded IP addresses (behind (ha)proxy)

### DIFF
--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -229,12 +229,16 @@ class EventBean
 
         // Build Context Stub
         $SERVER_PROTOCOL = $_SERVER['SERVER_PROTOCOL'] ?? '';
+        $remote_address = $_SERVER['REMOTE_ADDR'];
+        if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER) === true) {
+            $remote_address = $_SERVER['HTTP_X_FORWARDED_FOR'];
+        }
         $context         = [
             'request' => [
                 'http_version' => substr($SERVER_PROTOCOL, strpos($SERVER_PROTOCOL, '/')),
                 'method'       => $_SERVER['REQUEST_METHOD'] ?? 'cli',
                 'socket'       => [
-                    'remote_address' => $_SERVER['REMOTE_ADDR'] ?? '',
+                    'remote_address' => $remote_address ?? '',
                     'encrypted'      => isset($_SERVER['HTTPS'])
                 ],
                 'response' => $this->contexts['response'],


### PR DESCRIPTION
Same as #61, just different branches

> Since there was no way of setting the request-context outside of this library I figured that this would be the right place to support proxy/loadbalancer-setups.
Shoot me if anything.