### PR TITLE
fix REMOTE_ADDR fault tolerance code error and "Adding spans" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ Addings spans (https://www.elastic.co/guide/en/apm/server/current/transactions.h
 Please consult the documentation for your exact needs. Below is an example for adding a MySQL span.
 
 ```php
+$trxName = 'GET /some/transaction/name';
+
 // create the agent
 $agent = new \PhilKra\Agent(['appName' => 'Demo with Spans']);
 
 // start a new transaction
-$transaction = $agent->startTransaction('GET /some/transaction/name');
+$transaction = $agent->startTransaction($trxName);
 
 // create a span
 $spans = [];
@@ -103,6 +105,11 @@ $spans[] = [
 
 // add the array of spans to the transaction
 $transaction->setSpans($spans);
+
+// Do some stuff you want to watch ...
+sleep(1);
+
+$agent->stopTransaction($trxName);
 
 // send our transactions to te apm
 $agent->send();

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -229,7 +229,7 @@ class EventBean
 
         // Build Context Stub
         $SERVER_PROTOCOL = $_SERVER['SERVER_PROTOCOL'] ?? '';
-        $remote_address = $_SERVER['REMOTE_ADDR'];
+        $remote_address = $_SERVER['REMOTE_ADDR'] ?? '';
         if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER) === true) {
             $remote_address = $_SERVER['HTTP_X_FORWARDED_FOR'];
         }
@@ -238,7 +238,7 @@ class EventBean
                 'http_version' => substr($SERVER_PROTOCOL, strpos($SERVER_PROTOCOL, '/')),
                 'method'       => $_SERVER['REQUEST_METHOD'] ?? 'cli',
                 'socket'       => [
-                    'remote_address' => $remote_address ?? '',
+                    'remote_address' => $remote_address,
                     'encrypted'      => isset($_SERVER['HTTPS'])
                 ],
                 'response' => $this->contexts['response'],


### PR DESCRIPTION

1. I found an error during the initial use, as follows:

```
Caught exception: [line]: 232, [file]: .../vendor/philkra/elastic-apm-php-agent/src/Events/EventBean.php, [msg]: Undefined index: REMOTE_ADDR
```

After troubleshooting I have fixed the fault tolerance code, please check. 

2. "Adding spans" Demo error

After a very tangled investigation, it was found that there was a problem with the Demo call. I submitted a fix commit

Thank you.