### PR TITLE
Reset error and transaction stores on send when not active

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -90,7 +90,7 @@ class Agent
      *
      * @return void
      */
-    public function __construct(array $config, array $sharedContext = [], EventFactoryInterface $eventFactory = null)
+    public function __construct(array $config, array $sharedContext = [], EventFactoryInterface $eventFactory = null, TransactionsStore $transactionsStore = null, ErrorsStore $errorsStore = null)
     {
         // Init Agent Config
         $this->config = new Config($config);
@@ -111,8 +111,8 @@ class Agent
         $this->sharedContext['cookies'] = $this->config->get('cookies', []);
 
         // Initialize Event Stores
-        $this->transactionsStore = new TransactionsStore();
-        $this->errorsStore       = new ErrorsStore();
+        $this->transactionsStore = $transactionsStore ?? new TransactionsStore();
+        $this->errorsStore       = $errorsStore ?? new ErrorsStore();
 
         // Start Global Agent Timer
         $this->timer = new Timer();
@@ -221,6 +221,8 @@ class Agent
     {
         // Is the Agent enabled ?
         if ($this->config->get('active') === false) {
+            $this->errorsStore->reset();
+            $this->transactionsStore->reset();
             return true;
         }
 

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -2,7 +2,11 @@
 namespace PhilKra\Tests;
 
 use \PhilKra\Agent;
+use PhilKra\Stores\ErrorsStore;
+use PhilKra\Stores\TransactionsStore;
 use \PhilKra\Transaction\Summary;
+use PHPUnit\Framework\MockObject\MockObject;
+use Yaoi\Mock;
 
 /**
  * Test Case for @see \PhilKra\Agent
@@ -91,4 +95,24 @@ final class AgentTest extends TestCase {
     $agent->stopTransaction( 'unknown' );
   }
 
+  public function testClearErrorStoreOnSendWhenNotActive()
+  {
+      /** @var TransactionsStore|MockObject $transactionStore */
+      $transactionStore = $this->createMock(TransactionsStore::class);
+      /** @var ErrorsStore|MockObject $errorStore */
+      $errorStore = $this->createMock(ErrorsStore::class);
+
+      $agent = new Agent(
+          [ 'appName' => 'phpunit_1', 'active' => false ],
+          [],
+          null,
+          $transactionStore,
+          $errorStore
+      );
+
+      $transactionStore->expects($this->once())->method('reset');
+      $errorStore->expects($this->once())->method('reset');
+
+      $agent->send();
+  }
 }


### PR DESCRIPTION
The caller expects that the error and transaction stores are reset when Agent::send() is called. For consistency that should also be done when the agent is not active.