### PR TITLE
Add possibility to setup custom request

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -170,7 +170,7 @@ class Agent
      *
      * @param string $name
      *
-     * @return void
+     * @return Transaction
      */
     public function getTransaction(string $name)
     {


### PR DESCRIPTION
In some cases it can be useful to have opportunity setup custom request data. 

E.g. I have custom proxy setup with another IP forwarding and need to change $remote_address before i send data to APM agent.

```php
$transaction = $agent->getTransaction('myTransaction');
$request = $transaction->generateRequest();
$request['socket']['remote_address'] = $_SERVER['HTTP_X_REAL_IP'];
$transaction->setRequest($request);
$agent->send();
```