### PR TITLE
Supportv2 spans

### DIFF
--- a/src/Events/DefaultEventFactory.php
+++ b/src/Events/DefaultEventFactory.php
@@ -19,4 +19,12 @@ final class DefaultEventFactory implements EventFactoryInterface
     {
         return new Transaction($name, $contexts, $start);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createSpan(string $name, array $contexts, Transaction $parentTransaction, ?Span $parentSpan = null): Span
+    {
+        return new Span($name, $contexts, $parentTransaction, $parentSpan);
+    }
 }

--- a/src/Events/Error.php
+++ b/src/Events/Error.php
@@ -50,56 +50,9 @@ class Error extends EventBean implements \JsonSerializable
                     'message'    => $this->throwable->getMessage(),
                     'type'       => get_class($this->throwable),
                     'code'       => $this->throwable->getCode(),
-                    'stacktrace' => $this->mapStacktrace(),
+                    'stacktrace' => $this->mapStacktrace($this->throwable->getTrace()),
                 ],
             ]
         ];
     }
-
-    /**
-     * Map the Stacktrace to Schema
-     *
-     * @return array
-     */
-    final private function mapStacktrace() : array
-    {
-        $stacktrace = [];
-
-        foreach ($this->throwable->getTrace() as $trace) {
-            $item = [
-              'function' => $trace['function'] ?? '(closure)'
-            ];
-
-            if (isset($trace['line']) === true) {
-                $item['lineno'] = $trace['line'];
-            }
-
-            if (isset($trace['file']) === true) {
-                $item += [
-                    'filename' => basename($trace['file']),
-                    'abs_path' => $trace['file']
-                ];
-            }
-
-            if (isset($trace['class']) === true) {
-                $item['module'] = $trace['class'];
-            }
-            if (isset($trace['type']) === true) {
-                $item['type'] = $trace['type'];
-            }
-
-            if (!isset($item['lineno'])) {
-                $item['lineno'] = 0;
-            }
-
-            if (!isset($item['filename'])) {
-                $item['filename'] = '(anonymous)';
-            }
-
-            array_push($stacktrace, $item);
-        }
-
-        return $stacktrace;
-    }
-
 }

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -27,7 +27,7 @@ class EventBean
      * Id of the whole trace forest and is used to uniquely identify a distributed trace through a system
      * @link https://www.w3.org/TR/trace-context/#trace-id
      *
-     * @var string
+     * @var float
      */
     private $traceId;
 
@@ -62,7 +62,7 @@ class EventBean
      *
      * @var array
      */
-    private $contexts = [
+    protected $contexts = [
         'request'  => [],
         'user'     => [],
         'custom'   => [],
@@ -374,7 +374,7 @@ class EventBean
      *
      * @return array
      */
-    final protected function getContext() : array
+    protected function getContext() : array
     {
         $context = [
             'request' => empty($this->contexts['request']) ? $this->generateRequest() : $this->contexts['request']
@@ -404,8 +404,12 @@ class EventBean
      * @param $backTrace
      * @return array
      */
-    protected function mapStacktrace($backTrace) : array
+    protected function mapStacktrace($backTrace) : ?array
     {
+        if (!$backTrace)
+        {
+            return null;
+        }
         $stacktrace = [];
 
         foreach ($backTrace as $trace) {

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -186,6 +186,14 @@ class EventBean
     }
 
     /**
+     * @return array
+     */
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    /**
      * Set Meta data of User Context
      *
      * @param array $userContext
@@ -388,5 +396,52 @@ class EventBean
         }
 
         return $context;
+    }
+
+    /**
+     * Map the Stacktrace to Schema
+     *
+     * @param $backTrace
+     * @return array
+     */
+    protected function mapStacktrace($backTrace) : array
+    {
+        $stacktrace = [];
+
+        foreach ($backTrace as $trace) {
+            $item = [
+                'function' => $trace['function'] ?? '(closure)'
+            ];
+
+            if (isset($trace['line']) === true) {
+                $item['lineno'] = $trace['line'];
+            }
+
+            if (isset($trace['file']) === true) {
+                $item += [
+                    'filename' => basename($trace['file']),
+                    'abs_path' => $trace['file']
+                ];
+            }
+
+            if (isset($trace['class']) === true) {
+                $item['module'] = $trace['class'];
+            }
+            if (isset($trace['type']) === true) {
+                $item['type'] = $trace['type'];
+            }
+
+            if (!isset($item['lineno'])) {
+                $item['lineno'] = 0;
+            }
+
+            if (!isset($item['filename'])) {
+                $item['filename'] = '(anonymous)';
+            }
+
+            array_push($stacktrace, $item);
+        }
+
+        return $stacktrace;
     }
 }

--- a/src/Events/EventFactoryInterface.php
+++ b/src/Events/EventFactoryInterface.php
@@ -17,8 +17,21 @@ interface EventFactoryInterface
     /**
      * Creates a new transaction
      *
-     * @param string $name
-     * @param array  $contexts
+     * @param string     $name
+     * @param array      $contexts
+     * @param float|null $start
+     * @return Transaction
      */
-    public function createTransaction(string $name, array $contexts, float $start = null): Transaction;
+    public function createTransaction(string $name, array $contexts, ?float $start = null): Transaction;
+
+    /**
+     * Creates a span inside an existing transaction
+     *
+     * @param string      $name
+     * @param array       $contexts
+     * @param Transaction $parentTransaction
+     * @param Span|null   $parentSpan
+     * @return Span
+     */
+    public function createSpan(string $name, array $contexts, Transaction $parentTransaction, ?Span $parentSpan = null): Span;
 }

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -49,6 +49,11 @@ class Span extends EventBean implements \JsonSerializable
     private $parentSpan;
 
     /**
+     * @var Transaction
+     */
+    private $transaction;
+
+    /**
      * Create the Transaction
      *
      * @param string      $name
@@ -60,6 +65,7 @@ class Span extends EventBean implements \JsonSerializable
     {
         parent::__construct($contexts, $transaction);
         $this->setSpanName($name);
+        $this->transaction = $transaction;
         $this->parentSpan = $parentSpan;
         $transaction->addSpan($this);
         $this->timer = new Timer();

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace PhilKra\Events;
+
+use PhilKra\Helper\Timer;
+
+/**
+ *
+ * A Span inside a transaction
+ *
+ * @link https://www.elastic.co/guide/en/apm/server/master/span-api.html
+ *
+ * "required": ["duration", "name", "type"]
+ * "required": ["id", "transaction_id", "trace_id", "parent_id"]
+ */
+class Span extends EventBean implements \JsonSerializable
+{
+    /**
+     * Span Name
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * Transaction Timer
+     *
+     * @var \PhilKra\Helper\Timer
+     */
+    private $timer;
+
+    /**
+     * Summary of this Transaction
+     *
+     * @var array
+     */
+    private $summary = [
+        'duration'  => 0.0,
+        'backtrace' => null,
+    ];
+
+    private $captureStackTrace = true;
+
+    private $dropSpan = false;
+
+    /**
+     * @var Span|null
+     */
+    private $parentSpan;
+
+    /**
+     * Create the Transaction
+     *
+     * @param string      $name
+     * @param array       $contexts
+     * @param Transaction $transaction
+     * @param Span|null   $parentSpan
+     */
+    public function __construct(string $name, array $contexts, Transaction $transaction, Span $parentSpan = null)
+    {
+        parent::__construct($contexts, $transaction);
+        $this->setSpanName($name);
+        $this->parentSpan = $parentSpan;
+        $transaction->addSpan($this);
+        $this->timer = new Timer();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCaptureStackTrace(): bool
+    {
+        return $this->captureStackTrace;
+    }
+
+    /**
+     * @param bool $captureStackTrace
+     */
+    public function setCaptureStackTrace(bool $captureStackTrace): void
+    {
+        $this->captureStackTrace = $captureStackTrace;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDropSpan(): bool
+    {
+        return $this->dropSpan;
+    }
+
+    /**
+     * @param bool $dropSpan
+     */
+    public function setDropSpan(bool $dropSpan): void
+    {
+        $this->dropSpan = $dropSpan;
+    }
+
+    /**
+    * Start the Transaction
+    *
+    * @return void
+    */
+    public function start()
+    {
+        $this->transaction->pushActiveSpan($this);
+        $this->timer->start();
+    }
+
+    /**
+     * Stop the Transaction
+     *
+     * @param integer|null $duration
+     *
+     * @return void
+     */
+    public function stop(int $duration = null)
+    {
+        // Stop the Timer
+        $this->timer->stop();
+        $this->transaction->popActiveSpan($this);
+
+        // Store Summary
+        $this->summary['duration']  = $duration ?? round($this->timer->getDurationInMilliseconds(), 3);
+        $this->summary['backtrace'] = $this->isCaptureStackTrace() ? debug_backtrace($this->getTransaction()->getBacktraceLimit()) : null;
+    }
+
+    /**
+    * Set the Transaction Name
+    *
+    * @param string $name
+    *
+    * @return void
+    */
+    public function setSpanName(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+    * Get the Span Name
+    *
+    * @return string
+    */
+    public function getSpanName() : string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function getTransaction(): Transaction
+    {
+        return $this->transaction;
+    }
+
+    /**
+     * @return Span|null
+     */
+    public function getParentSpan(): ?Span
+    {
+        return $this->parentSpan;
+    }
+
+    /**
+     * @param Span|null $parentSpan
+     */
+    public function setParentSpan(?Span $parentSpan): void
+    {
+        $this->parentSpan = $parentSpan;
+    }
+
+    /**
+    * Get the Summary of this Transaction
+    *
+    * @return array
+    */
+    public function getSummary() : array
+    {
+        return $this->summary;
+    }
+
+    protected function getContext() : array
+    {
+        $contexts = $this->contexts;
+        unset($contexts['response']);
+        return \array_filter($contexts);
+    }
+
+    /**
+    * Serialize Transaction Event
+    *
+    * @return array
+    */
+    public function jsonSerialize() : array
+    {
+        $jsonData = [
+            'id'             => $this->getId(),
+            'transaction_id' => $this->getTransaction()->getId(),
+            'parent_id'      => $this->parentSpan ? $this->parentSpan->getId() : $this->getTransaction()->getId(),
+            'trace_id'       => $this->getTransaction()->getId(),
+            'name'           => $this->getSpanName(),
+            'timestamp'      => $this->getTimestamp(),
+            'duration'       => $this->summary['duration'],
+            'context'        => $this->getContext(),
+            'stacktrace'     => $this->mapStacktrace($this->summary['backtrace']),
+        ];
+
+        $meta = $this->getMeta();
+        unset($meta['result']);
+        $jsonData = \array_merge($jsonData, $meta);
+
+        return $jsonData;
+    }
+}

--- a/src/Events/Transaction.php
+++ b/src/Events/Transaction.php
@@ -245,7 +245,7 @@ class Transaction extends EventBean implements \JsonSerializable
                 $dropCount++;
                 continue;
             }
-            $spans[] = $span;
+            $spans[] = $span->jsonSerialize();
         }
 
         return $spans;

--- a/src/Exception/Transaction/NoTransactionInProgressException.php
+++ b/src/Exception/Transaction/NoTransactionInProgressException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PhilKra\Exception\Transaction;
+
+/**
+ * Trying to create a span when a transaction is no in progress
+ */
+class NoTransactionInProgressException extends \Exception
+{
+    public function __construct(string $message = '', int $code = 0, Throwable $previous = null)
+    {
+        parent::__construct(sprintf('The span "%s" requires a transaction.', $message), $code, $previous);
+    }
+}


### PR DESCRIPTION
I've been working on improving nested span support so it is ergonomically easier to use, ie incrementally calling 'startSpan' on the agent and letting it work out nesting as required.

I didn't notice that APM Server v2 apparently supports fully nested transactions, so the `currentTransaction` bits doesn't work well

Appears to work well enough, but  probably needs some code style cleanup