### PR TITLE
Add handling for keyword fields with a maximum length of 1024 characters

### DIFF
--- a/src/Events/Error.php
+++ b/src/Events/Error.php
@@ -2,6 +2,8 @@
 
 namespace PhilKra\Events;
 
+use PhilKra\Helper\Encoding;
+
 /**
  *
  * Event Bean for Error wrapping
@@ -45,10 +47,10 @@ class Error extends EventBean implements \JsonSerializable
                 'trace_id'       => $this->getTraceId(),
                 'timestamp'      => $this->getTimestamp(),
                 'context'        => $this->getContext(),
-                'culprit'        => sprintf('%s:%d', $this->throwable->getFile(), $this->throwable->getLine()),
+                'culprit'        => Encoding::keywordField(sprintf('%s:%d', $this->throwable->getFile(), $this->throwable->getLine())),
                 'exception'      => [
                     'message'    => $this->throwable->getMessage(),
-                    'type'       => get_class($this->throwable),
+                    'type'       => Encoding::keywordField(get_class($this->throwable)),
                     'code'       => $this->throwable->getCode(),
                     'stacktrace' => $this->mapStacktrace(),
                 ],

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -2,6 +2,8 @@
 
 namespace PhilKra\Events;
 
+use PhilKra\Helper\Encoding;
+
 /**
  *
  * EventBean for occurring events such as Exceptions or Transactions
@@ -272,11 +274,11 @@ class EventBean
             'response' => $this->contexts['response'],
             'url'          => [
                 'protocol' => $http_or_https,
-                'hostname' => $_SERVER['SERVER_NAME'] ?? '',
+                'hostname' => Encoding::keywordField($_SERVER['SERVER_NAME'] ?? ''),
                 'port'     => $_SERVER['SERVER_PORT'] ?? 0,
-                'pathname' => $_SERVER['SCRIPT_NAME'] ?? '',
-                'search'   => '?' . (($_SERVER['QUERY_STRING'] ?? '') ?? ''),
-                'full' => isset($_SERVER['HTTP_HOST']) ? $http_or_https . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] : '',
+                'pathname' => Encoding::keywordField($_SERVER['SCRIPT_NAME'] ?? ''),
+                'search'   => Encoding::keywordField('?' . (($_SERVER['QUERY_STRING'] ?? '') ?? '')),
+                'full' => Encoding::keywordField(isset($_SERVER['HTTP_HOST']) ? $http_or_https . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] : ''),
             ],
             'headers' => [
                 'user-agent' => $headers['User-Agent'] ?? '',

--- a/src/Events/Metadata.php
+++ b/src/Events/Metadata.php
@@ -4,6 +4,7 @@ namespace PhilKra\Events;
 
 use PhilKra\Agent;
 use PhilKra\Helper\Config;
+use PhilKra\Helper\Encoding;
 
 /**
  *
@@ -40,8 +41,8 @@ class Metadata extends EventBean implements \JsonSerializable
         return [
             'metadata' => [
                 'service' => [
-                    'name'    => $this->config->get('appName'),
-                    'version' => $this->config->get('appVersion'),
+                    'name'    => Encoding::keywordField($this->config->get('appName')),
+                    'version' => Encoding::keywordField($this->config->get('appVersion')),
                     'framework' => [
                         'name' => $this->config->get('framework') ?? '',
                         'version' => $this->config->get('frameworkVersion') ?? '',
@@ -57,10 +58,10 @@ class Metadata extends EventBean implements \JsonSerializable
                         'name'    => Agent::NAME,
                         'version' => Agent::VERSION
                     ],
-                    'environment' => $this->config->get('environment')
+                    'environment' => Encoding::keywordField($this->config->get('environment'))
                 ],
                 'system' => [
-                    'hostname'     => $this->config->get('hostname'),
+                    'hostname'     => Encoding::keywordField($this->config->get('hostname')),
                     'architecture' => php_uname('m'),
                     'platform'     => php_uname('s')
                 ]

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -2,6 +2,7 @@
 
 namespace PhilKra\Events;
 
+use PhilKra\Helper\Encoding;
 use PhilKra\Helper\Timer;
 
 /**
@@ -153,11 +154,11 @@ class Span extends TraceableEvent implements \JsonSerializable
                 'transaction_id' => $this->getParentId(),
                 'trace_id'       => $this->getTraceId(),
                 'parent_id'      => $this->getParentId(),
-                'type'           => $this->type,
-                'action'         => $this->action,
+                'type'           => Encoding::keywordField($this->type),
+                'action'         => Encoding::keywordField($this->action),
                 'context'        => $this->context,
                 'duration'       => $this->duration,
-                'name'           => $this->getName(),
+                'name'           => Encoding::keywordField($this->getName()),
                 'stacktrace'     => $this->stacktrace,
                 'sync'           => false,
                 'timestamp'      => $this->getTimestamp(),

--- a/src/Events/Transaction.php
+++ b/src/Events/Transaction.php
@@ -3,6 +3,7 @@
 namespace PhilKra\Events;
 
 use PhilKra\Helper\Timer;
+use PhilKra\Helper\Encoding;
 
 /**
  *
@@ -139,11 +140,11 @@ class Transaction extends TraceableEvent implements \JsonSerializable
                 'trace_id'   => $this->getTraceId(),
                 'id'         => $this->getId(),
                 'parent_id'  => $this->getParentId(),
-                'type'       => $this->getMetaType(),
+                'type'       => Encoding::keywordField($this->getMetaType()),
                 'duration'   => $this->summary['duration'],
                 'timestamp'  => $this->getTimestamp(),
                 'result'     => $this->getMetaResult(),
-                'name'       => $this->getTransactionName(),
+                'name'       => Encoding::keywordField($this->getTransactionName()),
                 'context'    => $this->getContext(),
                 'sampled'    => null,
                 'span_count' => [

--- a/src/Helper/Encoding.php
+++ b/src/Helper/Encoding.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PhilKra\Helper;
+
+/*
+ * Functions to convert values for transmission to ElasticSearch.
+ */
+class Encoding
+{
+
+    /**
+     * The maximum number of characters that are accepted in a keyword field.
+     */
+    const KEYWORD_MAX_LENGTH = 1024;
+
+
+    /**
+     * Limit the size of keyword fields. This is the same approach used by the Python APM client.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function keywordField($value): string
+    {
+        if (strlen($value) > self::KEYWORD_MAX_LENGTH && mb_strlen($value, 'UTF-8') > self::KEYWORD_MAX_LENGTH) { // strlen is faster (O(1)), so we prefer to first check using it, and then double-checking with the slower mb_strlen (O(n)) only when necessary
+            return mb_substr($value, 0, self::KEYWORD_MAX_LENGTH - 1, 'UTF-8') . '…';
+        }
+
+        return $value;
+    }
+}

--- a/src/Helper/Encoding.php
+++ b/src/Helper/Encoding.php
@@ -20,7 +20,7 @@ class Encoding
      * @param string $value
      * @return string
      */
-    public static function keywordField($value): string
+    public static function keywordField($value)
     {
         if (strlen($value) > self::KEYWORD_MAX_LENGTH && mb_strlen($value, 'UTF-8') > self::KEYWORD_MAX_LENGTH) { // strlen is faster (O(1)), so we prefer to first check using it, and then double-checking with the slower mb_strlen (O(n)) only when necessary
             return mb_substr($value, 0, self::KEYWORD_MAX_LENGTH - 1, 'UTF-8') . '…';

--- a/tests/Helper/EncodingTest.php
+++ b/tests/Helper/EncodingTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace PhilKra\Tests\Helper;
+
+use \PhilKra\Helper\Encoding;
+use PhilKra\Tests\TestCase;
+
+/**
+ * Test Case for @see \PhilKra\Helper\Encoding
+ */
+final class EncodingTest extends TestCase {
+
+    /**
+     * @covers \PhilKra\Helper\Encoding::keywordField
+     */
+    public function testShortInput() {
+
+        $input = "abcdefghijklmnopqrstuvwxyz1234567890";
+
+        $this->assertEquals( $input, Encoding::keywordField($input) );
+
+    }
+
+    /**
+     * @covers \PhilKra\Helper\Encoding::keywordField
+     */
+    public function testLongInput() {
+
+        $input = str_repeat("abc123", 200);
+        $output = str_repeat("abc123", 170) . 'abc' . '…';
+
+        $this->assertEquals( $output, Encoding::keywordField($input) );
+
+    }
+
+    /**
+     * @covers \PhilKra\Helper\Encoding::keywordField
+     */
+    public function testLongMultibyteInput() {
+
+        $input = str_repeat("中国日本韓国合衆国", 200);
+        $output = str_repeat("中国日本韓国合衆国", 113) . '中国日本韓国' . '…';
+
+        $this->assertEquals( $output, Encoding::keywordField($input) );
+
+    }
+
+}


### PR DESCRIPTION
When the ElasticSearch APM agent sends values for certain fields that are longer than 1024 characters, an exception is thrown:
```
{
  "accepted": 12,
  "errors": [
    {
      "message": "error validating JSON document against schema: I[#] S[#] doesn't validate with \"transaction#\"\n  I[#] S[#/allOf/3] allOf failed\n    I[#/context/request/url/search] S[#/allOf/3/properties/context/properties/request/properties/url/properties/search/maxLength] length must be \u003c= 1024, but got 1411",
      "document": "{\"transaction\":{\"trace_id\":\"e11c7e8a9f59efddc48537ec80515602\",\"id\":\"cbf74982abf1f97b\",\"parent_id\":null,\"type\":\"generic\",\"duration\":3625.9340000000002,\"timestamp\":1571250468353990,\"result\":\"200\",\"name\":\"[omitted]\",\"context\":{\"request\":{\"http_version\":\"\\/2.0\",\"method\":\"GET\",\"socket\":{\"remote_address\":\"169.10.176.228\",\"encrypted\":true},\"response\":{\"finished\":true,\"headers_sent\":true,\"status_code\":200},\"url\":{\"protocol\":\"https\",\"hostname\":\"[omitted]\",\"port\":\"443\",\"pathname\":\"\\/index.php\",\"search\":\"[a very long, omitted value]\",\"full\":\"[a very long, omitted value]\"},\"headers\":{\"user-agent\":\"Mozilla\\/5.0 (X11; Fedora; Linux x86_64) AppleWebKit\\/537.36 (KHTML, like Gecko) Chrome\\/71.0.3578.98 Safari\\/537.36\",\"cookie\":\"[omitted]\"},\"env\":{\"SERVER_SOFTWARE\":\"nginx\\/1.13.6\"}}}},\"sampled\":null,\"span_count\":{\"started\":0,\"dropped\":0}}}"
    }
  ]
}
```

The particular implementation here is as follows:
mb_substr is used to perform substring extraction; ElasticSearch uses UTF-8 exclusively, so this is the encoding given to mb_substr. In addition, in order to check string length, strlen is first used (it is constant time), and only if strlen exceeds the character limit is mb_substr used (which is linear time).

The keyword handing is added to most of the locations it is found in the Python agent (https://github.com/elastic/apm-agent-python/search?q=keyword_field&unscoped_q=keyword_field); a few are omitted where it doesn't seem to make any reasonable sense (e.g. the PHP version, and exceptions codes; while both technically can exceed the character limit, they should really only do so in extremely atypical situations).

The keyword handling was also omitted from tag names (simply because I wasn't 100% confident in modifying that code).