### PR TITLE
Force port to be integer in default request

### DIFF
--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -275,7 +275,7 @@ class EventBean
             'url'          => [
                 'protocol' => $http_or_https,
                 'hostname' => Encoding::keywordField($_SERVER['SERVER_NAME'] ?? ''),
-                'port'     => $_SERVER['SERVER_PORT'] ?? 0,
+                'port'     => (int) $_SERVER['SERVER_PORT'] ?? 0,
                 'pathname' => Encoding::keywordField($_SERVER['SCRIPT_NAME'] ?? ''),
                 'search'   => Encoding::keywordField('?' . (($_SERVER['QUERY_STRING'] ?? '') ?? '')),
                 'full' => Encoding::keywordField(isset($_SERVER['HTTP_HOST']) ? $http_or_https . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] : ''),


### PR DESCRIPTION
Sometimes you receive an empty string in the $_SERVER['SERVER_PORT']. That causes apm server call to be failed: 

```
Client error: `POST https://apm-server/intake/v2/events` resulted in a `400 Bad Request` response:
{
  "accepted": 0,
  "errors": [
    {
      "message": "strconv.Atoi: parsing \"\": invalid syntax",
      "document":  (truncated...)
```