### PR TITLE
feat: allow start time for Spans

### DIFF
--- a/src/Events/DefaultEventFactory.php
+++ b/src/Events/DefaultEventFactory.php
@@ -23,9 +23,9 @@ final class DefaultEventFactory implements EventFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function newSpan(string $name, EventBean $parent): Span
+    public function newSpan(string $name, EventBean $parent, float $startTime = null): Span
     {
-        return new Span($name, $parent);
+        return new Span($name, $parent, $startTime);
     }
 
     /**

--- a/src/Events/EventFactoryInterface.php
+++ b/src/Events/EventFactoryInterface.php
@@ -27,12 +27,13 @@ interface EventFactoryInterface
     /**
      * Creates a new Span
      *
-     * @param string    $name
-     * @param EventBean $parent
+     * @param string     $name
+     * @param EventBean  $parent
+     * @param float|null $startTime
      *
      * @return Span
      */
-    public function newSpan(string $name, EventBean $parent): Span;
+    public function newSpan(string $name, EventBean $parent, float $startTime = null): Span;
 
     /**
      * Creates a new Metricset

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -53,14 +53,15 @@ class Span extends TraceableEvent implements \JsonSerializable
     private $stacktrace = [];
 
     /**
-     * @param string $name
-     * @param EventBean $parent
+     * @param string     $name
+     * @param EventBean  $parent
+     * @param float|null $startTime
      */
-    public function __construct(string $name, EventBean $parent)
+    public function __construct(string $name, EventBean $parent, float $startTime = null)
     {
         parent::__construct([]);
         $this->name  = trim($name);
-        $this->timer = new Timer();
+        $this->timer = new Timer($startTime);
         $this->setParent($parent);
     }
 
@@ -159,6 +160,7 @@ class Span extends TraceableEvent implements \JsonSerializable
                 'type'           => Encoding::keywordField($this->type),
                 'action'         => Encoding::keywordField($this->action),
                 'context'        => $this->getContext(),
+                'start'          => $this->timer->getStartTimeInMilliseconds(),
                 'duration'       => $this->duration,
                 'name'           => Encoding::keywordField($this->getName()),
                 'stacktrace'     => $this->stacktrace,

--- a/src/Helper/Timer.php
+++ b/src/Helper/Timer.php
@@ -62,6 +62,38 @@ class Timer
     }
 
     /**
+     * Get the start time of this Timer in MicroSeconds
+     *
+     * @throws \PhilKra\Exception\Timer\NotStartedException
+     *
+     * @return float
+     */
+    public function getStartTime() : float
+    {
+        if ($this->startedOn === null) {
+            throw new NotStartedException();
+        }
+
+        return $this->toMicro($this->startedOn);
+    }
+
+    /**
+     * Get the start time of this Timer in MilliSeconds
+     *
+     * @throws \PhilKra\Exception\Timer\NotStartedException
+     *
+     * @return float
+     */
+    public function getStartTimeInMilliseconds() : float
+    {
+        if ($this->startedOn === null) {
+            throw new NotStartedException();
+        }
+
+        return $this->toMilli($this->startedOn);
+    }
+
+    /**
      * Get the elapsed Duration of this Timer in MicroSeconds
      *
      * @throws \PhilKra\Exception\Timer\NotStoppedException


### PR DESCRIPTION
There are some cases, where we already know the start time for a Span, and this information can be provided when the Span is created. Some examples:
- For database queries, we know the duration and can infer the start time from there.
- Application boot time.