### PR TITLE
fix: remove unused context from Span

### DIFF
--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -45,11 +45,6 @@ class Span extends TraceableEvent implements \JsonSerializable
     /**
      * @var mixed array|null
      */
-    private $context = null;
-
-    /**
-     * @var mixed array|null
-     */
     private $stacktrace = [];
 
     /**
@@ -115,18 +110,6 @@ class Span extends TraceableEvent implements \JsonSerializable
     public function setType(string $type)
     {
         $this->type = trim($type);
-    }
-
-    /**
-     * Provide additional Context to the Span
-     *
-     * @link https://www.elastic.co/guide/en/apm/server/master/span-api.html
-     *
-     * @param array $context
-     */
-    public function setContext(array $context)
-    {
-        $this->context = $context;
     }
 
     /**


### PR DESCRIPTION
I removed the `$context` variable because is not used anymore in the scope of a Span, and can lead to confusion. Its value gets lost and not sent to Elastic. `EventBean` holds the context that is serialized and sent to Elastic.

Closes https://github.com/philkra/elastic-apm-php-agent/issues/116