### PR TITLE
Fix fatal error caused by incorrect type

### DIFF
--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -94,7 +94,7 @@ class EventBean
         $this->contexts = array_merge($this->contexts, $contexts);
 
         // Get current Unix timestamp with seconds
-        $this->timestamp = round(microtime(true) * 1000000);
+        $this->timestamp = (int)round(microtime(true) * 1000000);
 
         // Set Parent Transaction
         if ($parent !== null) {


### PR DESCRIPTION
round() returns a float even in this case when it is obviously meant to create an integer. By casting to integer you will avoid the fatal error that occurs when getTimestamp() is called.