### PR TITLE
Fix the response context

### DIFF
--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -380,10 +380,9 @@ class EventBean
     final protected function getContext() : array
     {
         $context = [
-            'request' => empty($this->contexts['request']) ? $this->generateRequest() : $this->contexts['request']
+            'request' => empty($this->contexts['request']) ? $this->generateRequest() : $this->contexts['request'],
+            'response' => $this->contexts['response']
         ];
-
-        $context['response'] = $this->contexts['response'];
 
         // Add User Context
         if (empty($this->contexts['user']) === false) {

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -271,7 +271,6 @@ class EventBean
                 'remote_address' => $remote_address,
                 'encrypted'      => isset($_SERVER['HTTPS'])
             ],
-            'response' => $this->contexts['response'],
             'url'          => [
                 'protocol' => $http_or_https,
                 'hostname' => Encoding::keywordField($_SERVER['SERVER_NAME'] ?? ''),
@@ -383,6 +382,8 @@ class EventBean
         $context = [
             'request' => empty($this->contexts['request']) ? $this->generateRequest() : $this->contexts['request']
         ];
+
+        $context['response'] = $this->contexts['response'];
 
         // Add User Context
         if (empty($this->contexts['user']) === false) {


### PR DESCRIPTION
Currently the `EventBean` is adding the response context inside of request context. As you can see on the [official documentation](https://github.com/elastic/apm-server/blob/635cfdce16a6cb6609dbf4358308ffcf483957e7/docs/spec/context.json) `request` and `response` objects must be in the same level (e.g context's root).  With this fix we can now see a dedicated tab to show response context on Kibana APM.