### PR TITLE
Allow using api keys for authorization

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -7,6 +7,7 @@ appName       : Name of this application, Required
 appVersion    : Application version, Default: ''
 serverUrl     : APM Server Endpoint, Default: 'http://127.0.0.1:8200'
 secretToken   : Secret token for APM Server, Default: null
+apiKey        : API key for APM Server, Default: null
 hostname      : Hostname to transmit to the APM Server, Default: gethostname()
 active        : Activate the APM Agent, Default: true
 timeout       : Guzzle Client timeout, Default: 5

--- a/src/Helper/Config.php
+++ b/src/Helper/Config.php
@@ -67,6 +67,7 @@ class Config
         return [
             'serverUrl'      => 'http://127.0.0.1:8200',
             'secretToken'    => null,
+            'apiKey'         => null,
             'hostname'       => gethostname(),
             'appVersion'     => '',
             'active'         => true,

--- a/src/Middleware/Connector.php
+++ b/src/Middleware/Connector.php
@@ -139,6 +139,11 @@ class Connector
             $headers['Authorization'] = sprintf('Bearer %s', $this->config->get('secretToken'));
         }
 
+        // Add Api key to Header
+        if ($this->config->get('apiKey') !== null) {
+            $headers['Authorization'] = sprintf('ApiKey %s', $this->config->get('apiKey'));
+        }
+
         return $headers;
     }
 

--- a/tests/Helper/ConfigTest.php
+++ b/tests/Helper/ConfigTest.php
@@ -24,6 +24,7 @@ final class ConfigTest extends TestCase {
 
     $this->assertArrayHasKey( 'appName', $config );
     $this->assertArrayHasKey( 'secretToken', $config );
+    $this->assertArrayHasKey( 'apiKey', $config );
     $this->assertArrayHasKey( 'serverUrl', $config );
     $this->assertArrayHasKey( 'hostname', $config );
     $this->assertArrayHasKey( 'active', $config );
@@ -37,6 +38,7 @@ final class ConfigTest extends TestCase {
 
     $this->assertEquals( $config['appName'], $appName );
     $this->assertNull( $config['secretToken'] );
+    $this->assertNull( $config['apiKey'] );
     $this->assertEquals( $config['serverUrl'], 'http://127.0.0.1:8200' );
     $this->assertEquals( $config['hostname'], gethostname() );
     $this->assertFalse( $config['active'] );
@@ -60,6 +62,7 @@ final class ConfigTest extends TestCase {
     $init = [
       'appName'       => sprintf( 'app_name_%d', rand( 10, 99 ) ),
       'secretToken'   => hash( 'tiger128,3', time() ),
+      'apiKey'        => 'fooBar123',
       'serverUrl'     => sprintf( 'https://node%d.domain.tld:%d', rand( 10, 99 ), rand( 1000, 9999 ) ),
       'appVersion'    => sprintf( '%d.%d.42', rand( 0, 3 ), rand( 0, 10 ) ),
       'frameworkName' => uniqid(),

--- a/tests/Traits/Events/StacktraceTest.php
+++ b/tests/Traits/Events/StacktraceTest.php
@@ -14,12 +14,12 @@ final class StacktraceTest extends TestCase {
     /** @var Stacktrace|PHPUnit_Framework_MockObject_MockObject */
     private $stacktraceMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->stacktraceMock = $this->getMockForTrait(Stacktrace::class);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->stacktraceMock = null;
     }


### PR DESCRIPTION
Allow the usage of [api keys](https://www.elastic.co/guide/en/apm/server/current/api-key.html) when talking to the APM server.